### PR TITLE
Allows a choice of to which connection endpoints are added

### DIFF
--- a/hapi.js
+++ b/hapi.js
@@ -119,7 +119,13 @@ function configServer(server) {
 
   _.each(_routes, function(route) {
     if (route.hasVariants()) {
-      server.route({
+
+      var connection = server;
+
+      if (route.connection()) {
+        connection = server.select(route.connection());
+      }
+      connection.route({
         method: route.method(),
         path: route.path(),
         config: route.config(),

--- a/lib/admin/index.js
+++ b/lib/admin/index.js
@@ -4,7 +4,14 @@ var _ = require('lodash');
 
 module.exports = function(server, mocker) {
 
-  server.route({
+  var connection = server;
+
+  if (mocker.connection()) {
+    connection = server.select(mocker.connection());
+  }
+
+
+  connection.route({
     method: 'GET',
     path: '/_admin',
     handler: ensureInitialized(function(request, reply) {
@@ -22,7 +29,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/route/{id}',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -34,7 +41,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/action',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -46,7 +53,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/state/reset',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -55,7 +62,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/input/reset',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -64,7 +71,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/global/input/{pluginId}',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -73,7 +80,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/api/profile',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -82,7 +89,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/profile',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -91,7 +98,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/profile/{name}',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -100,7 +107,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'PUT',
     path: '/_admin/api/profile/{name}',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -109,7 +116,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/proxy',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -118,7 +125,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/api/har',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -127,7 +134,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'POST',
     path: '/_admin/api/har',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -141,7 +148,7 @@ module.exports = function(server, mocker) {
     }
   });
 
-  server.route({
+  connection.route({
     method: 'PATCH',
     path: '/_admin/api/har',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -150,7 +157,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'DELETE',
     path: '/_admin/api/har',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -159,7 +166,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/api/har/{id}',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {
@@ -168,7 +175,7 @@ module.exports = function(server, mocker) {
     })
   });
 
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/lib/{name*}',
     handler: function(request, reply) {
@@ -177,7 +184,7 @@ module.exports = function(server, mocker) {
   });
 
   var compiledSource;
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/app.js',
     handler: function(request, reply) {
@@ -192,7 +199,7 @@ module.exports = function(server, mocker) {
     }
   });
 
-  server.route({
+  connection.route({
     method: 'GET',
     path: '/_admin/inputs.js',
     handler: function(request, reply) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,13 @@ var smocksInstance = module.exports = {
     return smocksInstance;
   },
 
+  connection: function(connection) {
+    if (connection) {
+      smocksInstance._connection = connection;
+    }
+    return smocksInstance._connection;
+  },
+
   route: function(data) {
     if (!data.path) {
       throw new Error('Routes must be in the form of {path: "...", method: "..."}');

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -9,6 +9,7 @@ var Route = function(data, mocker) {
   this._id = data.id || this._method + ':' + this._path;
 
   this._config = data.config;
+  this._connection = data.connection;
   this._input = data.input;
   this._meta = data.meta;
   this._variants = {};
@@ -51,6 +52,10 @@ _.extend(Route.prototype, {
 
   method: function() {
     return this._method;
+  },
+
+  connection: function() {
+    return this._connection;
   },
 
   path: function() {


### PR DESCRIPTION
I didn't add docs yet, but let me know what you think.

This allows to do:

Smocks.connection(<label>)

and

Smocks.route({
connection: <label>
})
