### PR TITLE
respondWithVariantFile function added

### DIFF
--- a/api.md
+++ b/api.md
@@ -735,6 +735,9 @@ Convienance method for creating a default variant (id of "default") and then cal
 #### respondWithFile(filePath)
 Convienance method for creating a default variant (id of "default") and then calling [Variant:respondWithFile](#project/jhudson8/smocks/snippet/method/Variant/respondWithFile) on the variant.
 
+#### respondWithVariantFile(mockDir, fileName)
+Convienance method for creating a default json response based on a response.json file and then calling [Variant:respondWithJsonData](#project/jhudson8/smocks/snippet/method/Variant/respondWithVariantFile) on the variant.
+
 
 ### Variant
 #### route(options)
@@ -792,3 +795,20 @@ Remember that using ```./``` will refer to the top level module directory (the d
 This would cause a request to ```/customer/1``` to return the file ```./customer-1.json```
 
 Return the same Variant object for chaining.
+
+#### respondWithVariantFile(mockDir, fileName)
+* ***mockDir***: the path to root mocking directory
+* ***fileName***: the name of the file to serve out
+
+This method enables you to have your json files in a route identical directory structure.
+
+Remember that using ```./``` will refer to the top level module directory (the directory where ```node_modules``` exists regardless of the location of the file that is referring to a file location with ```./```);
+
+```javascript
+    var smocks = require('smocks');
+    smocks.route({path: '/customer/{id}'}).respondWithVariantFile('./mocked-data', 'response.json')
+    .start(...)
+```
+
+This would cause a request to ```/customer/123``` to return the file ```./mocked-data/customer/123/response.json```
+

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -202,9 +202,9 @@ _.extend(Route.prototype, {
     return variant.respondWithFile(fileName);
   },
 
-  respondWithJsonData: function(dataLocation, fileName) {
+  respondWithVariantFile: function(mockDir, fileName) {
     var variant = this.variant('default');
-    return variant.createJsonResponse(variant._id, this._path, dataLocation, fileName);
+    return variant.getJsonResponse(variant._id, this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -199,7 +199,13 @@ _.extend(Route.prototype, {
 
   respondWithFile: function(fileName) {
     var variant = this.variant('default');
-    return variant.withFile(fileName);
+    return variant.respondWithFile(fileName);
+  },
+
+  respondWithJsonData: function(dataLocation, fileName) {
+    console.log('route-json');
+    var variant = this.variant('default');
+    return variant.respondWithJsonData(this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -204,7 +204,7 @@ _.extend(Route.prototype, {
 
   respondWithVariantFile: function(mockDir, fileName) {
     var variant = this.variant('default');
-    return variant.getJsonResponse(variant._id, this._path, dataLocation, fileName);
+    return variant.getJsonResponse(variant._id, this._path, mockDir, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -199,7 +199,12 @@ _.extend(Route.prototype, {
 
   respondWithFile: function(fileName) {
     var variant = this.variant('default');
-    return variant.withFile(fileName);
+    return variant.respondWithFile(fileName);
+  },
+
+  respondWithJsonData: function(dataLocation, fileName) {
+    var variant = this.variant('default');
+    return variant.createJsonResponse(this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,6 +59,24 @@ _.extend(Variant.prototype, {
     });
   },
 
+  respondWithJsonData: function(dataLocation, fileName) {
+    console.log('variant-json');
+    var self = this;
+    return self.createJsonResponse(self._route._path, dataLocation, fileName);
+  },
+
+  createJsonResponse: function(path, dataLocation, fileName) {
+    return this.respondWith(function(request, reply) {
+      var pattern = /{\w+}\/*/g;
+      path = path.replace(pattern, '');
+      var executingDir = require('path').dirname(require.main.filename);
+      var dataFilePath = executingDir + '/' + dataLocation + path + 'default' + '/' + fileName;
+      var response = require(dataFilePath);
+
+      reply(response);
+    });
+  },
+
   variant: function() {
     return this._route.variant.apply(this._route, arguments);
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -68,7 +68,7 @@ _.extend(Variant.prototype, {
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
       path = path.replace(pattern, '');
-      var dataFilePath = dataLocation + path + variant + '/' + fileName;
+      var dataFilePath = mockDir + path + variant + '/' + fileName;
       reply.file(dataFilePath);
     });
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,20 +59,17 @@ _.extend(Variant.prototype, {
     });
   },
 
-  respondWithJsonData: function(dataLocation, fileName) {
+  respondWithVariantFile: function(mockDir, fileName) {
     var self = this;
-    return self.createJsonResponse(self._id, self._route._path, dataLocation, fileName);
+    return self.getJsonResponse(self._id, self._route._path, mockDir, fileName);
   },
 
-  createJsonResponse: function(variant, path, dataLocation, fileName) {
+  getJsonResponse: function(variant, path, mockDir, fileName) {
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
       path = path.replace(pattern, '');
-      var executingDir = require('path').dirname(require.main.filename);
-      var dataFilePath = executingDir + '/' + dataLocation + path + variant + '/' + fileName;
-      var response = require(dataFilePath);
-
-      reply(response);
+      var dataFilePath = dataLocation + path + variant + '/' + fileName;
+      reply.file(dataFilePath);
     });
   },
 

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,6 +59,19 @@ _.extend(Variant.prototype, {
     });
   },
 
+  respondWithJsonData: function(path, dataLocation, fileName) {
+    return this.respondWith(function(request, reply) {
+      console.log(this._id);
+      var pattern = /{\w+}\/*/g;
+      path = path.replace(pattern, '');
+      var executingDir = require('path').dirname(require.main.filename);
+      var dataFilePath = executingDir + '/' + dataLocation + path + 'default' + '/' + fileName;
+      var response = require(dataFilePath);
+
+      reply(response);
+    });
+  },
+
   variant: function() {
     return this._route.variant.apply(this._route, arguments);
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -60,7 +60,6 @@ _.extend(Variant.prototype, {
   },
 
   respondWithJsonData: function(dataLocation, fileName) {
-    console.log('variant-json');
     var self = this;
     return self.createJsonResponse(self._id, self._route._path, dataLocation, fileName);
   },


### PR DESCRIPTION
The idea with this is that the user can have a route identical directory structure with the mocking responses:

Lets say you have a directory structure like this:

`project/mocked-data/product/api/awesome/test/response.json`
`project/mocked-data/product/api/awesome/test2/response.json`

Then you can write your endpoint code like this, without having to write the complete path to the file, this makes it simpler for the user to manage several response files for different routes and variants:

`smocks.route({
    id: 'test',
    label: 'testing',
    path: '/product/api/awesome/{productId}',
    variantLabel: 'default' 

```
}).respondWithVariantFile('./mocked-data', 'response.json')

.variant({
    id: 'test2',
    label: 'variant',

}).respondWithVariantFile('./mocked-data', 'response.json'); ` 
```
