### PR TITLE
Implemented respondWithFile()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 .DS_Store
 .generator-release
+
+#IDE files
+.idea

--- a/api.md
+++ b/api.md
@@ -735,6 +735,9 @@ Convienance method for creating a default variant (id of "default") and then cal
 #### respondWithFile(filePath)
 Convienance method for creating a default variant (id of "default") and then calling [Variant:respondWithFile](#project/jhudson8/smocks/snippet/method/Variant/respondWithFile) on the variant.
 
+#### respondWithVariantFile(mockDir, fileName)
+Convienance method for creating a default json response based on a response.json file and then calling [Variant:respondWithJsonData](#project/jhudson8/smocks/snippet/method/Variant/respondWithVariantFile) on the variant.
+
 
 ### Variant
 #### route(options)
@@ -792,3 +795,20 @@ Remember that using ```./``` will refer to the top level module directory (the d
 This would cause a request to ```/customer/1``` to return the file ```./customer-1.json```
 
 Return the same Variant object for chaining.
+
+#### respondWithVariantFile(mockDir, fileName)
+* ***mockDir***: the path to root mocking directory
+* ***fileName***: the name of the file to serve out
+
+This method enables you to have your json files in a route identical directory structure.
+
+Remember that using ```./``` will refer to the top level module directory (the directory where ```node_modules``` exists regardless of the location of the file that is referring to a file location with ```./```);
+
+```javascript
+    var smocks = require('smocks');
+    smocks.route({path: '/customer/{id}'}).respondWithVariantFile('./mocked-data', 'response.json')
+    .start(...)
+```
+
+This would cause a request to ```/customer/123``` to return the file ```./mocked-data/customer/123/response.json```
+

--- a/api.md
+++ b/api.md
@@ -810,3 +810,5 @@ Example 2
 ```
 
 This would cause a request to ```/customer/123``` on the variant *invalid_customerid* to return the file ```./mocked-data/customer/invalid_customerid/response.json``` where ```default```is the variant id, the dynamic ```{id}``` in the path will not be used here.
+
+If the ```response.json``` file doesn't exist in the variant directory, smocks will search for it in the parent directory (i.e. ```./mocked-data/customer/response.json```) and use it for both *example 1* and *example 2* above. This is useful if you want to respond with the same file for all your variants on the same path. 

--- a/api.md
+++ b/api.md
@@ -781,34 +781,34 @@ Return the same Variant object for chaining.
 ```
 
 
-#### respondWithFile(filePath)
-* ***filePath***: the path to the file to serve out (any route variables can be used in the file path as well)
+#### respondWithFile(options)
+* ***options***: options to override the default values.
+  * ***mockDir***: The base directory where the mocking data exists. 
+    * *default value set to* ```./mocked-data```
+  * ***fileName***: The file name smocks will search for in the ***mockDir*** directory structure and then set as the response.
+    * *default value set to* ```response.json```
+  * ***statusCode***: The status code of the response.
+    * *Default value set to* ```200```
+
+This method enables you to have your json files in a route similar directory structure as follows. 
 
 Remember that using ```./``` will refer to the top level module directory (the directory where ```node_modules``` exists regardless of the location of the file that is referring to a file location with ```./```);
 
+Example 1
 ```javascript
     var smocks = require('smocks');
-    smocks.route({path: '/customer/{id}'}).respondWithFile('./customer-{id}.json')
+    smocks.route({path: '/customer/{id}'}).respondWithFile()
     .start(...)
 ```
 
-This would cause a request to ```/customer/1``` to return the file ```./customer-1.json```
+This would cause a request to ```/customer/123``` to return the file ```./mocked-data/customer/default/response.json``` where ```default```is the variant id, the dynamic ```{id}``` in the path will not be used here.
 
-Return the same Variant object for chaining.
-
-#### respondWithVariantFile(mockDir, fileName)
-* ***mockDir***: the path to root mocking directory
-* ***fileName***: the name of the file to serve out
-
-This method enables you to have your json files in a route identical directory structure.
-
-Remember that using ```./``` will refer to the top level module directory (the directory where ```node_modules``` exists regardless of the location of the file that is referring to a file location with ```./```);
+Example 2
 
 ```javascript
     var smocks = require('smocks');
-    smocks.route({path: '/customer/{id}'}).respondWithVariantFile('./mocked-data', 'response.json')
+    smocks.route({path: '/customer/{id}'}).variant({id: 'invalid_customerid'}).respondWithFile({mockDir: './mocks, fileName: 'variantfile.json', statusCode: 422})
     .start(...)
 ```
 
-This would cause a request to ```/customer/123``` to return the file ```./mocked-data/customer/123/response.json```
-
+This would cause a request to ```/customer/123``` on the variant *invalid_customerid* to return the file ```./mocked-data/customer/invalid_customerid/response.json``` where ```default```is the variant id, the dynamic ```{id}``` in the path will not be used here.

--- a/api.md
+++ b/api.md
@@ -782,13 +782,14 @@ Return the same Variant object for chaining.
 
 
 #### respondWithFile(options)
-* ***options***: options to override the default values.
+* ***options***: options to override the default values. *(These options can also be globally provided in the smocks core options when starting the server, see ([Starting the server](#section/Concepts/Starting%2520the%2520server))*
   * ***mockDir***: The base directory where the mocking data exists. 
     * *default value set to* ```./mocked-data```
   * ***fileName***: The file name smocks will search for in the ***mockDir*** directory structure and then set as the response.
     * *default value set to* ```response.json```
   * ***statusCode***: The status code of the response.
     * *Default value set to* ```200```
+    
 
 This method enables you to have your json files in a route similar directory structure as follows. 
 

--- a/api.md
+++ b/api.md
@@ -732,11 +732,8 @@ Refer to [global:plugin](#project/jhudson8/smocks/snippet/method/global/plugin)
 Convienance method for creating a default variant (id of "default") and then calling [Variant:respondWith](#project/jhudson8/smocks/snippet/method/Variant/respondWith) on the variant.
 
 
-#### respondWithFile(filePath)
+#### respondWithFile(options)
 Convienance method for creating a default variant (id of "default") and then calling [Variant:respondWithFile](#project/jhudson8/smocks/snippet/method/Variant/respondWithFile) on the variant.
-
-#### respondWithVariantFile(mockDir, fileName)
-Convienance method for creating a default json response based on a response.json file and then calling [Variant:respondWithJsonData](#project/jhudson8/smocks/snippet/method/Variant/respondWithVariantFile) on the variant.
 
 
 ### Variant

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -197,9 +197,9 @@ _.extend(Route.prototype, {
     return variant.respondWith(responder);
   },
 
-  respondWithFile: function(mockDir, fileName) {
+  respondWithFile: function(options) {
     var variant = this.variant('default');
-    return variant.respondWithFile(mockDir, fileName);
+    return variant.respondWithFile(options);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -202,9 +202,9 @@ _.extend(Route.prototype, {
     return variant.respondWithFile(fileName);
   },
 
-  respondWithJsonData: function(dataLocation, fileName) {
+  respondWithVariantFile: function(mockDir, fileName) {
     var variant = this.variant('default');
-    return variant.createJsonResponse(variant._id, this._path, dataLocation, fileName);
+    return variant.getJsonResponse(variant._id, this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -199,7 +199,13 @@ _.extend(Route.prototype, {
 
   respondWithFile: function(fileName) {
     var variant = this.variant('default');
-    return variant.withFile(fileName);
+    return variant.respondWithFile(fileName);
+  },
+
+  respondWithJsonData: function(dataLocation, fileName) {
+    console.log('route-json');
+    var variant = this.variant('default');
+    return variant.respondWithJsonData(this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -204,7 +204,7 @@ _.extend(Route.prototype, {
 
   respondWithVariantFile: function(mockDir, fileName) {
     var variant = this.variant('default');
-    return variant.getJsonResponse(variant._id, this._path, dataLocation, fileName);
+    return variant.getJsonResponse(variant._id, this._path, mockDir, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -197,14 +197,9 @@ _.extend(Route.prototype, {
     return variant.respondWith(responder);
   },
 
-  respondWithFile: function(fileName) {
+  respondWithFile: function(mockDir, fileName) {
     var variant = this.variant('default');
-    return variant.respondWithFile(fileName);
-  },
-
-  respondWithVariantFile: function(mockDir, fileName) {
-    var variant = this.variant('default');
-    return variant.getJsonResponse(variant._id, this._path, mockDir, fileName);
+    return variant.respondWithFile(mockDir, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -199,7 +199,12 @@ _.extend(Route.prototype, {
 
   respondWithFile: function(fileName) {
     var variant = this.variant('default');
-    return variant.withFile(fileName);
+    return variant.respondWithFile(fileName);
+  },
+
+  respondWithJsonData: function(dataLocation, fileName) {
+    var variant = this.variant('default');
+    return variant.createJsonResponse(this._path, dataLocation, fileName);
   },
 
   activeVariant: function(request) {

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -62,32 +62,27 @@ _.extend(Variant.prototype, {
         statusCode: smocks.initOptions.statusCode || 200
       }, options);
 
-      if(options.statusCode == 200) {
-        var pattern = /{\w+}\/*/g;
-        var path = options.path.replace(pattern, '');
-        var dataVariantFilePath = Path.join(options.mockDir, path, options.variant_id, options.fileName);
+      var pattern = /{\w+}\/*/g;
+      var path = options.path.replace(pattern, '');
+      var dataVariantFilePath = Path.join(options.mockDir, path, options.variant_id, options.fileName);
 
-        // Search variant directory
-        Fs.stat(dataVariantFilePath, function (err) {
-          if (err) {
-            // Search parent directory
-            var dataCommonFilePath = Path.join(options.mockDir, path, options.fileName);
-            Fs.stat(dataCommonFilePath, function (err) {
-              if(err) {
-                console.error('Mocking data file not found: ' + dataVariantFilePath);
-                reply().code(404);
-              } else {
-                reply.file(dataCommonFilePath);
-              }
-            });
-          } else {
-            reply.file(dataVariantFilePath);
-          }
-        });
-      } else {
-        // Reply with status code only
-        reply().code(options.statusCode);
-      }
+      // Search variant directory
+      Fs.stat(dataVariantFilePath, function (err) {
+        if (err) {
+          // Search parent directory
+          var dataCommonFilePath = Path.join(options.mockDir, path, options.fileName);
+          Fs.stat(dataCommonFilePath, function (err) {
+            if(err) {
+              console.error('Mocking data file not found: ' + dataVariantFilePath);
+              reply().code(404);
+            } else {
+              reply(JSON.parse(Fs.readFileSync(dataCommonFilePath, 'utf8'))).code(options.statusCode);
+            }
+          });
+        } else {
+          reply(JSON.parse(Fs.readFileSync(dataVariantFilePath, 'utf8'))).code(options.statusCode);
+        }
+      });
     });
   },
 

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -60,22 +60,16 @@ _.extend(Variant.prototype, {
         statusCode: smocks.initOptions.statusCode || 200
       }, options);
 
-      var pattern = /{\w+}\/*/g;
+      var pattern = /[{}}]\/*/g;
       var path = self._route.path().replace(pattern, '');
-      var dataVariantFilePath = Path.join(options.mockDir, path, self.id() + '.json');
+      var httpMethod = self._route.method();
+      var dataFilePath = Path.join(options.mockDir, path, httpMethod, self.id() + '.json');
 
       // Search for variant file
-      Fs.readFile(dataVariantFilePath, function (err, variantData) {
+      Fs.readFile(dataFilePath, function (err, variantData) {
         if (err) {
-          // No variant file found, search for the default json file
-          var dataDefaultFilePath = Path.join(options.mockDir, path, options.fileName);
-          Fs.readFile(dataDefaultFilePath, function (err, defaultData) {
-            if (err) {
-              return reply().code(404);
-            } else {
-              reply(defaultData).type('application/json').code(options.statusCode);
-            }
-          });
+          console.error('Mocking data file not found: ' + dataFilePath);
+          return reply().code(404);
         } else {
           reply(variantData).type('application/json').code(options.statusCode);
         }

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -48,23 +48,21 @@ _.extend(Variant.prototype, {
   },
 
   respondWithFile: function(options) {
-    options = _.extend({
-      variant_id: this.id(),
-      path: this._route.path(),
-    }, options);
+    var self = this;
 
     return this.respondWith(function(request, reply) {
+      // Intentionally requiring smocks to lazy load options
       var smocks = require('./index');
 
       options = _.extend({
-        fileName: smocks.initOptions.fileName || 'response.json',
+        fileName: smocks.initOptions.fileName || 'default.json',
         mockDir: smocks.initOptions.mockDir || './mocked-data',
         statusCode: smocks.initOptions.statusCode || 200
       }, options);
 
       var pattern = /{\w+}\/*/g;
-      var path = options.path.replace(pattern, '');
-      var dataVariantFilePath = Path.join(options.mockDir, path, options.variant_id, options.fileName);
+      var path = self._route.path().replace(pattern, '');
+      var dataVariantFilePath = Path.join(options.mockDir, path, self.id(), options.fileName);
 
       // Search variant directory
       Fs.stat(dataVariantFilePath, function (err) {
@@ -74,13 +72,13 @@ _.extend(Variant.prototype, {
           Fs.stat(dataCommonFilePath, function (err) {
             if(err) {
               console.error('Mocking data file not found: ' + dataVariantFilePath);
-              reply().code(404);
+              return reply().code(404);
             } else {
-              reply(JSON.parse(Fs.readFileSync(dataCommonFilePath, 'utf8'))).code(options.statusCode);
+              reply(Fs.readFileSync(dataCommonFilePath, 'utf8')).type('application/json').code(options.statusCode);
             }
           });
         } else {
-          reply(JSON.parse(Fs.readFileSync(dataVariantFilePath, 'utf8'))).code(options.statusCode);
+          reply(Fs.readFileSync(dataVariantFilePath, 'utf8')).type('application/json').code(options.statusCode);
         }
       });
     });

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,6 +59,24 @@ _.extend(Variant.prototype, {
     });
   },
 
+  respondWithJsonData: function(dataLocation, fileName) {
+    console.log('variant-json');
+    var self = this;
+    return self.createJsonResponse(self._route._path, dataLocation, fileName);
+  },
+
+  createJsonResponse: function(path, dataLocation, fileName) {
+    return this.respondWith(function(request, reply) {
+      var pattern = /{\w+}\/*/g;
+      path = path.replace(pattern, '');
+      var executingDir = require('path').dirname(require.main.filename);
+      var dataFilePath = executingDir + '/' + dataLocation + path + 'default' + '/' + fileName;
+      var response = require(dataFilePath);
+
+      reply(response);
+    });
+  },
+
   variant: function() {
     return this._route.variant.apply(this._route, arguments);
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -68,7 +68,7 @@ _.extend(Variant.prototype, {
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
       path = path.replace(pattern, '');
-      var dataFilePath = dataLocation + path + variant + '/' + fileName;
+      var dataFilePath = mockDir + path + variant + '/' + fileName;
       reply.file(dataFilePath);
     });
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,20 +59,17 @@ _.extend(Variant.prototype, {
     });
   },
 
-  respondWithJsonData: function(dataLocation, fileName) {
+  respondWithVariantFile: function(mockDir, fileName) {
     var self = this;
-    return self.createJsonResponse(self._id, self._route._path, dataLocation, fileName);
+    return self.getJsonResponse(self._id, self._route._path, mockDir, fileName);
   },
 
-  createJsonResponse: function(variant, path, dataLocation, fileName) {
+  getJsonResponse: function(variant, path, mockDir, fileName) {
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
       path = path.replace(pattern, '');
-      var executingDir = require('path').dirname(require.main.filename);
-      var dataFilePath = executingDir + '/' + dataLocation + path + variant + '/' + fileName;
-      var response = require(dataFilePath);
-
-      reply(response);
+      var dataFilePath = dataLocation + path + variant + '/' + fileName;
+      reply.file(dataFilePath);
     });
   },
 

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -46,20 +46,17 @@ _.extend(Variant.prototype, {
   },
 
   respondWithFile: function(options) {
-    // initOptions is initialized first after hapi.js is
-    // started, we need a way to initialize them before we
-    // load the endpoints.js
-    var smocks = require('./index');
-
-    options = _.extend({
-      // keeping response.json for making it easier for the user
-      // to add response files, let's discuss more in this
-      fileName: smocks.initOptions.fileName || 'response.json',
-      mockDir: smocks.initOptions.mockDir || './mocked-data',
-      statusCode: smocks.initOptions.statusCode || 200
-    }, options);
-
     return this.respondWith(function(request, reply) {
+      var smocks = require('./index');
+
+      options = _.extend({
+        // keeping response.json for making it easier for the user
+        // to add response files, let's discuss more in this
+        fileName: smocks.initOptions.fileName || 'response.json',
+        mockDir: smocks.initOptions.mockDir || './mocked-data',
+        statusCode: smocks.initOptions.statusCode || 200
+      }, options);
+
       var pattern = /{\w+}\/*/g;
       path = this._route.path.replace(pattern, '');
       var dataFilePath = options.mockDir + path + this.id() + '/' + options.fileName;

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -59,6 +59,19 @@ _.extend(Variant.prototype, {
     });
   },
 
+  respondWithJsonData: function(path, dataLocation, fileName) {
+    return this.respondWith(function(request, reply) {
+      console.log(this._id);
+      var pattern = /{\w+}\/*/g;
+      path = path.replace(pattern, '');
+      var executingDir = require('path').dirname(require.main.filename);
+      var dataFilePath = executingDir + '/' + dataLocation + path + 'default' + '/' + fileName;
+      var response = require(dataFilePath);
+
+      reply(response);
+    });
+  },
+
   variant: function() {
     return this._route.variant.apply(this._route, arguments);
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -60,7 +60,6 @@ _.extend(Variant.prototype, {
   },
 
   respondWithJsonData: function(dataLocation, fileName) {
-    console.log('variant-json');
     var self = this;
     return self.createJsonResponse(self._id, self._route._path, dataLocation, fileName);
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -66,12 +66,12 @@ _.extend(Variant.prototype, {
       var dataFilePath = Path.join(options.mockDir, path, httpMethod, self.id() + '.json');
 
       // Search for variant file
-      Fs.readFile(dataFilePath, function (err, variantData) {
+      Fs.readFile(dataFilePath, function (err, data) {
         if (err) {
           console.error('Mocking data file not found: ' + dataFilePath);
           return reply().code(404);
         } else {
-          reply(variantData).type('application/json').code(options.statusCode);
+          reply(data).type('application/json').code(options.statusCode);
         }
       });
     });

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -45,12 +45,25 @@ _.extend(Variant.prototype, {
     return this;
   },
 
-  respondWithFile: function(mockDir, fileName) {
+  respondWithFile: function(options) {
+    // initOptions is initialized first after hapi.js is
+    // started, we need a way to initialize them before we
+    // load the endpoints.js
+    var smocks = require('./index');
+
+    options = _.extend({
+      // keeping response.json for making it easier for the user
+      // to add response files, let's discuss more in this
+      fileName: smocks.initOptions.fileName || 'response.json',
+      mockDir: smocks.initOptions.mockDir || './mocked-data',
+      statusCode: smocks.initOptions.statusCode || 200
+    }, options);
+
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
-      path = _route.path.replace(pattern, '');
-      var dataFilePath = mockDir + path + this.id() + '/' + fileName;
-      reply.file(dataFilePath);
+      path = this._route.path.replace(pattern, '');
+      var dataFilePath = options.mockDir + path + this.id() + '/' + options.fileName;
+      reply.file(dataFilePath).code(options.statusCode);
     });
   },
 

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var fs = require('fs');
 
 var Variant = function(data, route) {
   if (_.isString(data)) {
@@ -46,21 +47,37 @@ _.extend(Variant.prototype, {
   },
 
   respondWithFile: function(options) {
+    options = _.extend({
+      variant_id: this.id(),
+      path: this._route.path(),
+    }, options);
+
     return this.respondWith(function(request, reply) {
       var smocks = require('./index');
 
       options = _.extend({
-        // keeping response.json for making it easier for the user
-        // to add response files, let's discuss more in this
         fileName: smocks.initOptions.fileName || 'response.json',
         mockDir: smocks.initOptions.mockDir || './mocked-data',
         statusCode: smocks.initOptions.statusCode || 200
       }, options);
 
-      var pattern = /{\w+}\/*/g;
-      path = this._route.path.replace(pattern, '');
-      var dataFilePath = options.mockDir + path + this.id() + '/' + options.fileName;
-      reply.file(dataFilePath).code(options.statusCode);
+      if(options.statusCode == 200) {
+        var pattern = /{\w+}\/*/g;
+        var path = options.path.replace(pattern, '');
+        var dataFilePath = options.mockDir + path + options.variant_id + '/' + options.fileName;
+
+        fs.stat(dataFilePath, function (err) {
+          if (err) {
+            var errorMessage = 'Mocking data file not found: ' + dataFilePath;
+            console.error(errorMessage);
+            reply().code(404);
+          } else {
+            reply.file(dataFilePath);
+          }
+        });
+      } else {
+        reply().code(options.statusCode);
+      }
     });
   },
 

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -45,30 +45,11 @@ _.extend(Variant.prototype, {
     return this;
   },
 
-  respondWithFile: function(fileName) {
-    return this.respondWith(function(request, reply) {
-      var self = this;
-      fileName = fileName.replace(/\{([^\}]+)\}/g, function(match, token) {
-        var val = request.params[token];
-        if (!val) {
-          val = self.state(token);
-        }
-        return val || match;
-      });
-      reply.file(fileName);
-    });
-  },
-
-  respondWithVariantFile: function(mockDir, fileName) {
-    var self = this;
-    return self.getJsonResponse(self._id, self._route._path, mockDir, fileName);
-  },
-
-  getJsonResponse: function(variant, path, mockDir, fileName) {
+  respondWithFile: function(mockDir, fileName) {
     return this.respondWith(function(request, reply) {
       var pattern = /{\w+}\/*/g;
-      path = path.replace(pattern, '');
-      var dataFilePath = mockDir + path + variant + '/' + fileName;
+      path = _route.path.replace(pattern, '');
+      var dataFilePath = mockDir + path + this.id() + '/' + fileName;
       reply.file(dataFilePath);
     });
   },

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
-var fs = require('fs');
+var Fs = require('fs');
+var Path = require('path');
 
 var Variant = function(data, route) {
   if (_.isString(data)) {
@@ -64,18 +65,27 @@ _.extend(Variant.prototype, {
       if(options.statusCode == 200) {
         var pattern = /{\w+}\/*/g;
         var path = options.path.replace(pattern, '');
-        var dataFilePath = options.mockDir + path + options.variant_id + '/' + options.fileName;
+        var dataVariantFilePath = Path.join(options.mockDir, path, options.variant_id, options.fileName);
 
-        fs.stat(dataFilePath, function (err) {
+        // Search variant directory
+        Fs.stat(dataVariantFilePath, function (err) {
           if (err) {
-            var errorMessage = 'Mocking data file not found: ' + dataFilePath;
-            console.error(errorMessage);
-            reply().code(404);
+            // Search parent directory
+            var dataCommonFilePath = Path.join(options.mockDir, path, options.fileName);
+            Fs.stat(dataCommonFilePath, function (err) {
+              if(err) {
+                console.error('Mocking data file not found: ' + dataVariantFilePath);
+                reply().code(404);
+              } else {
+                reply.file(dataCommonFilePath);
+              }
+            });
           } else {
-            reply.file(dataFilePath);
+            reply.file(dataVariantFilePath);
           }
         });
       } else {
+        // Reply with status code only
         reply().code(options.statusCode);
       }
     });

--- a/lib/variant-model.js
+++ b/lib/variant-model.js
@@ -62,23 +62,22 @@ _.extend(Variant.prototype, {
 
       var pattern = /{\w+}\/*/g;
       var path = self._route.path().replace(pattern, '');
-      var dataVariantFilePath = Path.join(options.mockDir, path, self.id(), options.fileName);
+      var dataVariantFilePath = Path.join(options.mockDir, path, self.id() + '.json');
 
-      // Search variant directory
-      Fs.stat(dataVariantFilePath, function (err) {
+      // Search for variant file
+      Fs.readFile(dataVariantFilePath, function (err, variantData) {
         if (err) {
-          // Search parent directory
-          var dataCommonFilePath = Path.join(options.mockDir, path, options.fileName);
-          Fs.stat(dataCommonFilePath, function (err) {
-            if(err) {
-              console.error('Mocking data file not found: ' + dataVariantFilePath);
+          // No variant file found, search for the default json file
+          var dataDefaultFilePath = Path.join(options.mockDir, path, options.fileName);
+          Fs.readFile(dataDefaultFilePath, function (err, defaultData) {
+            if (err) {
               return reply().code(404);
             } else {
-              reply(Fs.readFileSync(dataCommonFilePath, 'utf8')).type('application/json').code(options.statusCode);
+              reply(defaultData).type('application/json').code(options.statusCode);
             }
           });
         } else {
-          reply(Fs.readFileSync(dataVariantFilePath, 'utf8')).type('application/json').code(options.statusCode);
+          reply(variantData).type('application/json').code(options.statusCode);
         }
       });
     });


### PR DESCRIPTION
Ready for review. 

Implemented according to the following requirements:
- User should be able to just call a default method and the file should be automatically picked based on the api path that is mocked.
- Users should be able to provide a default file name during set up.
- User should be able to provide a default mocked data directory structure.
- User should be able to override the default directory structure and filename when writing mocks.
- Add feature to look for the response file in the absolute path based on variant. If file is not present then look for file a directory up than the variant to allow use of same response file.
