### PR TITLE
upgrade to babel@6

### DIFF
--- a/lib/admin/index.js
+++ b/lib/admin/index.js
@@ -207,7 +207,7 @@ module.exports = function(server, mocker) {
     handler: function(request, reply) {
       if (!compiledSource) {
         var source = fs.readFileSync(__dirname + '/config-page.js', {encoding: 'utf-8'});
-        compiledSource = require('babel').transform(source).code;
+        compiledSource = require('babel-core').transform(source).code;
       }
       reply(compiledSource);
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Joe Hudson <joehud@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "babel": "^5.8.23",
+    "babel-core": "^6.5.2",
     "hapi": "^8.6.1",
     "lodash": "^3.9.3",
     "mime-types": "^2.1.9",


### PR DESCRIPTION
Ideally this would be precompiled before npm published and babel wouldn’t be in the direct deps, but for now this won’t block people from using smocks alongside babel@6 when using npm@3
