### PR TITLE
added error handling when variant is incorrect for a url

### DIFF
--- a/lib/admin/api/route-update.js
+++ b/lib/admin/api/route-update.js
@@ -9,7 +9,10 @@ module.exports = function(route, mocker) {
     var input = payload.input;
 
     if (variantId) {
-      route.selectVariant(variantId, request);
+      var returnObj = route.selectVariant(variantId, request);
+      if(returnObj){
+        reply(returnObj);
+      }
     }
     if (input) {
       if (input.route) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -173,6 +173,8 @@ _.extend(Route.prototype, {
 
     if (match) {
       this._mocker.state.routeState(request)[this._id]._activeVariant = id;
+    } else {
+      return new Error("no variants found with id : " + id);
     }
   },
 


### PR DESCRIPTION
Hi @jhudson8 .  I have added some error handling when a variant is not matched while setting a variant.  I looked into the `Boom` api but the way `reply` is being wrapped while responding to a request, I couldn't get it to work.  Please let me know if there is a better way to do this error handling.  
